### PR TITLE
Bugfix renaming of columns in augment.MArrayLM

### DIFF
--- a/R/limma_tidiers.R
+++ b/R/limma_tidiers.R
@@ -106,6 +106,7 @@ tidy.MArrayLM <- function(x, intercept = FALSE, ...) {
 #'   \item{.p.value}{p-value generated from moderated F-statistic}
 #'   \item{.df.total}{total degrees of freedom per gene}
 #'   \item{.df.residual}{residual degrees of freedom per gene}
+#'   \item{.s2.prior}{prior estimate of residual variance}
 #'   \item{.s2.post}{posterior estimate of residual variance}
 #'
 #' @S3method augment MArrayLM
@@ -114,7 +115,7 @@ augment.MArrayLM <- function(x, data, ...) {
     cols <- c("sigma", "F", "F.p.value", "AMean", "df.total", "df.residual",
               "s2.prior", "s2.post")
     newnames <- c("sigma", "statistic", "p.value", "AMean", "df.total",
-                  "df.residual", "s2.post")
+                  "df.residual", "s2.prior", "s2.post")
     lst <- unclass(x)[cols]
     names(lst) <- paste0(".", newnames)
     ret <- cbind(.gene=rownames(x$coefficients), as.data.frame(compact(lst)))


### PR DESCRIPTION
The function `augment.MArrayLM()` in `limma_tidiers.R` listed originally 8 items in `cols`, but only 7 in `newnames`.
This caused `s2.prior` to be incorrectly renamed as `.s2.post` and left `s2.post` named as `NA.`
The element `s2.prior` has been added to `newnames` and a its description has been added to the documentation.