### PR TITLE
Correct rendering of titles

### DIFF
--- a/vignettes/biobroom_vignette.Rmd
+++ b/vignettes/biobroom_vignette.Rmd
@@ -167,7 +167,7 @@ ggplot(tidy_results, aes(x=estimate, y=log(p.value),
   ggtitle("Volcano Plot For Airway Data via DESeq2") + theme_bw()
 ```
 
-##edgeR objects
+## edgeR objects
 
 Here we use the  `hammer` dataset included in `biobroom` package. `edgeR` can be used to perform differential
 expression analysis as follows:
@@ -206,7 +206,7 @@ ggplot(tidy(et), aes(x=estimate, y=log(p.value), color=logCPM)) +
   theme_bw()
 ```
 
-##limma objects
+## limma objects
 
 To demonstrate how `biobroom` works with `limma` objects, we generate some simulated data to test the tidier for `limma` objects. 
 
@@ -241,7 +241,7 @@ ggplot(tidy(eb), aes(x=estimate, y=log(p.value), color=statistic)) +
 ```
 
 
-##ExpressionSet objects
+## ExpressionSet objects
 
 `tidy` can also be run directly on `ExpressionSet` objects, as described in another popular `Bioconductor` package `Biobase.` The
 `hammer` dataset we used above (which is included in the `biobroom` package) is an `ExpressionSet` object, so we'll use that to demonstrate.
@@ -265,7 +265,7 @@ ggplot(tidy(hammer, addPheno=TRUE), aes(x=protocol, y=log(value))) +
   geom_boxplot() + ggtitle("Boxplot Showing Effect of Protocol on Expression")
 ```
 
-##MSnSet Objects
+## MSnSet Objects
 
 `tidy` can also be run directly on `MSnSet` objects from `MSnbase`, which as specialised containers for quantitative proteomics data.
 


### PR DESCRIPTION
Added space after the title comments to correct visualize the titles (`##edgeR` -> `## edgeR`).

I would also suggest to use [BiocStyle](https://bioconductor.org/packages/BiocStyle) to make it more akin with other Bioconductor packages and adding an index to use those headers. 